### PR TITLE
feat: Standardize inputs for generative models

### DIFF
--- a/argo/gen_models/__init__.py
+++ b/argo/gen_models/__init__.py
@@ -78,7 +78,7 @@ class GenerationTask:
         'linker_generation',
         'property_optimization'
     ]
-    scaffold: Optional[str] = None
+    scaffold: Optional[Union[str, List[str]]] = None
     fragments: Optional[List[str]] = None
     seed_smiles: Optional[Union[str, List[str]]] = None
     labels: Optional[List[float]] = None
@@ -190,7 +190,29 @@ class SAFEGenerator(BaseGenerator):
         elif task.mode == 'scaffold_decoration':
             if not task.scaffold:
                 raise ValueError("A 'scaffold' must be provided for this task.")
-            return self.scaffold_decoration(task.scaffold, config)
+
+            scaffolds = [task.scaffold] if isinstance(task.scaffold, str) else task.scaffold
+            processing_mode = config.get('processing_mode', 'iterate') # iterate or sample
+            n_samples = config.get('n_samples', 1000)
+            samples_per_scaffold = n_samples // len(scaffolds)
+
+            all_generated = []
+
+            if processing_mode == 'iterate':
+                for scaffold in scaffolds:
+                    logging.info(f"Decorating scaffold: {scaffold} with {samples_per_scaffold} samples")
+                    config['n_samples'] = samples_per_scaffold
+                    all_generated.extend(self.scaffold_decoration(scaffold, config))
+            elif processing_mode == 'sample':
+                import random
+                for _ in range(n_samples):
+                    scaffold = random.choice(scaffolds)
+                    logging.info(f"Decorating scaffold: {scaffold} with 1 sample")
+                    config['n_samples'] = 1
+                    all_generated.extend(self.scaffold_decoration(scaffold, config))
+
+            return all_generated
+
         elif task.mode == 'linker_generation':
             if not task.fragments or len(task.fragments) != 2:
                 raise ValueError("A list of two 'fragments' must be provided for this task.")
@@ -222,7 +244,7 @@ class MolMIMClient(BaseGenerator):
             raise ValueError("Invalid server_address format. Expected 'hostname:port'.")
 
         self.base_url = f"http://{server_address}"
-        print(f"Attempting to connect to MolMIM service at: {self.base_url}")
+        logging.info(f"Attempting to connect to MolMIM service at: {self.base_url}")
 
         # Immediately perform a health check to ensure the server is ready.
         self._health_check()
@@ -241,7 +263,7 @@ class MolMIMClient(BaseGenerator):
 
             # Check the content of the response
             if response.json().get("status") == "ready":
-                print("Connection successful. MolMIM service is ready.")
+                 logging.info("Connection successful. MolMIM service is ready.")
             else:
                 raise ConnectionError(
                     f"Service at {self.base_url} is running but not ready. "
@@ -321,54 +343,76 @@ class MolMIMClient(BaseGenerator):
         return self._call_api(payload, endpoint="/generate")
 
     def generate(self, task: GenerationTask) -> List[str]:
-        if not task.seed_smiles or not isinstance(task.seed_smiles, str):
-            raise ValueError("A single 'seed_smiles' string must be provided for MolMiM.")
+        if not task.seed_smiles:
+            raise ValueError("A 'seed_smiles' string or list must be provided for MolMiM.")
+
+        seed_smiles_list = [task.seed_smiles] if isinstance(task.seed_smiles, str) else task.seed_smiles
 
         objective = task.objective or 'QED'
         config = task.config or {}
         n_samples = config.get('n_samples', 10)
         batch_size = config.get('batch_size', 10)
+        processing_mode = config.get('processing_mode', 'iterate')
 
-        optimize_params = {
-            "seed_smiles": task.seed_smiles,
-            "iterations": config.get('iterations', 10),
-            "min_similarity": config.get('min_similarity', 0.7),
-            "minimize": config.get('minimize', False),
-            "particles": config.get('particles', 30),
-            "property_name": objective,
-            "scaled_radius": config.get('scaled_radius', 1.0)
-        }
+        all_generated = []
 
-        generation_fn = None
-        if task.mode == 'property_optimization':
-            generation_fn = lambda n: self.optimize(algorithm='CMA-ES', n_samples=n, **optimize_params)
-        elif task.mode == 'biased_generation':
-            generation_fn = lambda n: self.optimize(algorithm='none', n_samples=n, **optimize_params)
-        else:
-            raise NotImplementedError(f"MolMiM does not support the '{task.mode}' generation mode.")
+        def run_generation(seed_smi, num_mols):
 
-        valid_smiles = []
-        generated_count = 0
-        while len(valid_smiles) < n_samples:
-            try:
-                smiles_batch = generation_fn(batch_size)
-                if not smiles_batch:
-                    logging.warning("MolMIMClient.generate returned no SMILES. Stopping generation.")
+            optimize_params = {
+                "seed_smiles": seed_smi,
+                "iterations": config.get('iterations', 10),
+                "min_similarity": config.get('min_similarity', 0.7),
+                "minimize": config.get('minimize', False),
+                "particles": config.get('particles', 30),
+                "property_name": objective,
+                "scaled_radius": config.get('scaled_radius', 1.0)
+            }
+
+            generation_fn = None
+            if task.mode == 'property_optimization':
+                generation_fn = lambda n: self.optimize(algorithm='CMA-ES', n_samples=n, **optimize_params)
+            elif task.mode == 'biased_generation':
+                generation_fn = lambda n: self.optimize(algorithm='none', n_samples=n, **optimize_params)
+            else:
+                raise NotImplementedError(f"MolMiM does not support the '{task.mode}' generation mode.")
+
+            valid_smiles = []
+            generated_count = 0
+            while len(valid_smiles) < num_mols:
+                try:
+                    smiles_batch = generation_fn(batch_size)
+                    if not smiles_batch:
+                        logging.warning("MolMIMClient.generate returned no SMILES. Stopping generation.")
+                        break
+                    generated_count += len(smiles_batch)
+
+                    for smi in smiles_batch:
+                        if validate_smiles(smi):
+                            valid_smiles.append(smi)
+                except requests.exceptions.RequestException as e:
+                    logging.error(f"MolMIM API call failed: {e}. Stopping generation.")
                     break
-                generated_count += len(smiles_batch)
 
-                for smi in smiles_batch:
-                    if validate_smiles(smi):
-                        valid_smiles.append(smi)
-            except requests.exceptions.RequestException as e:
-                logging.error(f"MolMIM API call failed: {e}. Stopping generation.")
-                break
+            if generated_count > 0:
+                validity = len(valid_smiles) / generated_count * 100
+                logging.info(f"MolMIMClient: Final validity: {validity:.2f}% ({len(valid_smiles)} valid SMILES from {generated_count} generated)")
 
-        if generated_count > 0:
-            validity = len(valid_smiles) / generated_count * 100
-            logging.info(f"MolMIMClient: Final validity: {validity:.2f}% ({len(valid_smiles)} valid SMILES from {generated_count} generated)")
+            return valid_smiles[:num_mols]
 
-        return valid_smiles[:n_samples]
+        if processing_mode == 'iterate':
+            samples_per_seed = n_samples // len(seed_smiles_list)
+            for seed in seed_smiles_list:
+                logging.info(f"Generating from seed: {seed} with {samples_per_seed} samples")
+                all_generated.extend(run_generation(seed, samples_per_seed))
+
+        elif processing_mode == 'sample':
+            import random
+            for _ in range(n_samples):
+                seed = random.choice(seed_smiles_list)
+                logging.info(f"Generating from seed: {seed} with 1 sample")
+                all_generated.extend(run_generation(seed, 1))
+
+        return all_generated
 
 class GEMGenerator(BaseGenerator):
     """
@@ -397,7 +441,7 @@ class GEMGenerator(BaseGenerator):
 
         if task.mode == 'de_novo':
             if self.finetuned:
-                print("GEM is finetuned. De novo generation is biased generation.")
+                logging.info("GEM is finetuned. De novo generation is biased generation.")
         elif task.mode == 'biased_generation':
             if not task.seed_smiles:
                 raise ValueError("'seed_smiles', list of SMILES for biasing, must be provided for this task.")

--- a/tests/gen_models/test_molmim.py
+++ b/tests/gen_models/test_molmim.py
@@ -34,6 +34,48 @@ def test_molmim_property_optimization(molmim_model):
         assert isinstance(smi, str)
 
 @pytest.mark.skipif(not MOLMIM_SERVER_ADDRESS, reason="MOLMIM_SERVER_ADDRESS not set")
+def test_molmim_biased_generation_list_iterate(molmim_model):
+    """Test MolMIM biased generation with a list of seeds (iterate)."""
+    seed_smiles = [
+        "CC(C)Cc1ccc(cc1)C(C)C(=O)O",
+        "CC1(C)C(C(=O)O)C1C(C=C(C)C)C"
+    ]
+    task = GenerationTask(
+        mode='biased_generation',
+        seed_smiles=seed_smiles,
+        config={
+            "n_samples": 4,
+            "processing_mode": "iterate"
+        }
+    )
+    result = molmim_model.generate(task)
+    assert isinstance(result, list)
+    assert len(result) > 0
+    for smi in result:
+        assert isinstance(smi, str)
+
+@pytest.mark.skipif(not MOLMIM_SERVER_ADDRESS, reason="MOLMIM_SERVER_ADDRESS not set")
+def test_molmim_biased_generation_list_sample(molmim_model):
+    """Test MolMIM biased generation with a list of seeds (sample)."""
+    seed_smiles = [
+        "CC(C)Cc1ccc(cc1)C(C)C(=O)O",
+        "CC1(C)C(C(=O)O)C1C(C=C(C)C)C"
+    ]
+    task = GenerationTask(
+        mode='biased_generation',
+        seed_smiles=seed_smiles,
+        config={
+            "n_samples": 4,
+            "processing_mode": "sample"
+        }
+    )
+    result = molmim_model.generate(task)
+    assert isinstance(result, list)
+    assert len(result) > 0
+    for smi in result:
+        assert isinstance(smi, str)
+
+@pytest.mark.skipif(not MOLMIM_SERVER_ADDRESS, reason="MOLMIM_SERVER_ADDRESS not set")
 def test_molmim_biased_generation(molmim_model):
     """Test MolMIM biased generation."""
     task = GenerationTask(

--- a/tests/gen_models/test_safe.py
+++ b/tests/gen_models/test_safe.py
@@ -47,6 +47,42 @@ def test_safegpt_scaffold_decoration(safegpt_model):
     for smi in result:
         assert isinstance(smi, str)
 
+def test_safegpt_scaffold_decoration_list_iterate(safegpt_model):
+    """Test SAFE-GPT scaffold decoration with a list of scaffolds (iterate)."""
+    scaffolds = ["[*]c1ccccc1[*]", "[*]C1CC1[*]"]
+    task = GenerationTask(
+        mode='scaffold_decoration',
+        scaffold=scaffolds,
+        config={
+            "n_samples": 4,
+            "batch_size": 2,
+            "processing_mode": "iterate"
+        }
+    )
+    result = safegpt_model.generate(task)
+    assert isinstance(result, list)
+    assert len(result) == 4
+    for smi in result:
+        assert isinstance(smi, str)
+
+def test_safegpt_scaffold_decoration_list_sample(safegpt_model):
+    """Test SAFE-GPT scaffold decoration with a list of scaffolds (sample)."""
+    scaffolds = ["[*]c1ccccc1[*]", "[*]C1CC1[*]"]
+    task = GenerationTask(
+        mode='scaffold_decoration',
+        scaffold=scaffolds,
+        config={
+            "n_samples": 4,
+            "batch_size": 2,
+            "processing_mode": "sample"
+        }
+    )
+    result = safegpt_model.generate(task)
+    assert isinstance(result, list)
+    assert len(result) == 4
+    for smi in result:
+        assert isinstance(smi, str)
+
 def test_safegpt_linker_generation(safegpt_model):
     """Test SAFE-GPT linker generation."""
     fragment1 = "[*]N1CCCCC1"


### PR DESCRIPTION
I've standardized the inputs for MolMIM and SAFE-GPT to accept lists of seed_smiles and scaffolds, respectively.

Here's a summary of the changes:
- Added 'iterate' and 'sample' processing modes.
- Replaced all print statements with logging.
- Updated tests to reflect the new functionality.