### PR TITLE
Refactor Generation Models for SMILES Validation and Batching

### DIFF
--- a/argo/gen_models/__init__.py
+++ b/argo/gen_models/__init__.py
@@ -82,7 +82,6 @@ class GenerationTask:
     scaffold: Optional[Union[str, List[str]]] = None
     fragments: Optional[List[str]] = None
     seed_smiles: Optional[Union[str, List[str]]] = None
-    labels: Optional[List[float]] = None
     objective: Optional[Union[str, Callable[[List[str]], List[float]]]] = None
     config: Dict[str, Any] = field(default_factory=dict)
 
@@ -127,302 +126,115 @@ class SAFEGenerator(BaseGenerator):
             designer = sf.SAFEDesign.load_default(device=device, verbose=False)
         self.designer = designer
 
-    def de_novo(self, n_samples: int = 1000, batch_size: int = 100, sanitize: bool = True, **kwargs) -> tuple[List[str], int]:
-        valid_smiles = []
-        generated_count = 0
-        
-        while len(valid_smiles) < n_samples:
-            current_batch_size = min(batch_size, n_samples - len(valid_smiles))
-            batch = self.designer.de_novo_generation(n_samples_per_trial=current_batch_size, n_trials=1, **kwargs)
-            
-            if not batch:
-                logging.warning("SAFEGenerator.de_novo returned no SMILES. Stopping generation.")
-                break
-            generated_count += len(batch)
-            
-            # Filter valid SMILES
-            for smi in batch:
-                if validate_smiles(smi):
-                    valid_smiles.append(smi)
-                    if len(valid_smiles) >= n_samples:
-                        break
-        
-        return valid_smiles[:n_samples], generated_count
+    def de_novo(self, batch_size: int = 100, **kwargs) -> List[str]:
+        """Generates a batch of molecules from scratch."""
+        return self.designer.de_novo_generation(n_samples_per_trial=batch_size, n_trials=1, **kwargs)
 
-    def scaffold_decoration(self, scaffold: str, n_samples: int = 1000, batch_size: int = 100, sanitize: bool = True, **kwargs) -> tuple[List[str], int]:
-        valid_smiles = []
-        generated_count = 0
-        
-        while len(valid_smiles) < n_samples:
-            current_batch_size = min(batch_size, n_samples - len(valid_smiles))
-            batch = self.designer.scaffold_decoration(scaffold=scaffold, n_samples_per_trial=current_batch_size, n_trials=1, **kwargs)
-            
-            if not batch:
-                logging.warning("SAFEGenerator.scaffold_decoration returned no SMILES. Stopping generation.")
-                break
-            generated_count += len(batch)
-            
-            # Filter valid SMILES
-            for smi in batch:
-                if validate_smiles(smi):
-                    valid_smiles.append(smi)
-                    if len(valid_smiles) >= n_samples:
-                        break
-        
-        return valid_smiles[:n_samples], generated_count
+    def scaffold_decoration(self, scaffold: str, batch_size: int = 100, **kwargs) -> List[str]:
+        """Generates a batch of molecules by decorating a scaffold."""
+        return self.designer.scaffold_decoration(scaffold=scaffold, n_samples_per_trial=batch_size, n_trials=1, **kwargs)
 
-    def linker_generation(self, fragment1: str, fragment2: str, n_samples: int = 1000, batch_size: int = 100, sanitize: bool = True, **kwargs) -> tuple[List[str], int]:
-        valid_smiles = []
-        generated_count = 0
-        
-        while len(valid_smiles) < n_samples:
-            current_batch_size = min(batch_size, n_samples - len(valid_smiles))
-            batch = self.designer.linker_generation(fragment1, fragment2, n_samples_per_trial=current_batch_size, n_trials=1, **kwargs)
-            
-            if not batch:
-                logging.warning("SAFEGenerator.linker_generation returned no SMILES. Stopping generation.")
-                break
-            generated_count += len(batch)
-            
-            # Filter valid SMILES
-            for smi in batch:
-                if validate_smiles(smi):
-                    valid_smiles.append(smi)
-                    if len(valid_smiles) >= n_samples:
-                        break
-        
-        return valid_smiles[:n_samples], generated_count
+    def linker_generation(self, fragment1: str, fragment2: str, batch_size: int = 100, **kwargs) -> List[str]:
+        """Generates a batch of molecules by linking two fragments."""
+        return self.designer.linker_generation(fragment1, fragment2, n_samples_per_trial=batch_size, n_trials=1, **kwargs)
 
     def generate(self, task: GenerationTask) -> List[str]:
         config = task.config or {}
+        n_samples = config.get('n_samples', 1000)
+        batch_size = config.get('batch_size', 100)
+        kwargs = {k: v for k, v in config.items() if k not in ['n_samples', 'batch_size', 'processing_mode']}
+
+        valid_smiles = []
+        generated_count = 0
+
         if task.mode == 'de_novo':
-            n_samples = config.get('n_samples', 1000)
-            batch_size = config.get('batch_size', 100)
-            sanitize = config.get('sanitize', True)
-            # Extract other kwargs for the underlying model
-            kwargs = {k: v for k, v in config.items() if k not in ['n_samples', 'batch_size', 'sanitize']}
-            result, generated_count = self.de_novo(n_samples=n_samples, batch_size=batch_size, sanitize=sanitize, **kwargs)
-            
-            # Log validity
-            if generated_count > 0:
-                validity = len(result) / generated_count * 100
-                logging.info(f"SAFEGenerator.{task.mode}: validity: {validity:.2f}% ({len(result)} valid SMILES from {generated_count} generated)")
-            
-            return result
+            while len(valid_smiles) < n_samples:
+                batch = self.de_novo(batch_size=batch_size, **kwargs)
+                if not batch:
+                    logging.warning("SAFEGenerator.de_novo returned no SMILES. Stopping generation.")
+                    break
+                generated_count += len(batch)
+
+                for smi in batch:
+                    if validate_smiles(smi):
+                        valid_smiles.append(smi)
+                        if len(valid_smiles) >= n_samples:
+                            break
             
         elif task.mode == 'scaffold_decoration':
             if not task.scaffold:
                 raise ValueError("A 'scaffold' must be provided for this task.")
 
             scaffolds = [task.scaffold] if isinstance(task.scaffold, str) else task.scaffold
-            processing_mode = config.get('processing_mode', 'iterate') # iterate or sample
-            n_samples = config.get('n_samples', 1000)
-            samples_per_scaffold = n_samples // len(scaffolds)
-            batch_size = config.get('batch_size', 100)
-            sanitize = config.get('sanitize', True)
-            # Extract other kwargs for the underlying model
-            kwargs = {k: v for k, v in config.items() if k not in ['n_samples', 'batch_size', 'sanitize', 'processing_mode']}
+            processing_mode = config.get('processing_mode', 'iterate')
+            scaffold_idx = 0
 
-            all_generated = []
-            total_generated_count = 0
-
-            if processing_mode == 'iterate':
-                for scaffold in scaffolds:
-                    logging.info(f"Decorating scaffold: {scaffold} with {samples_per_scaffold} samples")
-                    result, generated_count = self.scaffold_decoration(scaffold, n_samples=samples_per_scaffold, batch_size=batch_size, sanitize=sanitize, **kwargs)
-                    all_generated.extend(result)
-                    total_generated_count += generated_count
-            elif processing_mode == 'sample':
-                for _ in range(n_samples):
+            while len(valid_smiles) < n_samples:
+                if processing_mode == 'iterate':
+                    scaffold = scaffolds[scaffold_idx % len(scaffolds)]
+                    scaffold_idx += 1
+                elif processing_mode == 'sample':
                     scaffold = random.choice(scaffolds)
-                    logging.info(f"Decorating scaffold: {scaffold} with 1 sample")
-                    result, generated_count = self.scaffold_decoration(scaffold, n_samples=1, batch_size=batch_size, sanitize=sanitize, **kwargs)
-                    all_generated.extend(result)
-                    total_generated_count += generated_count
 
-            # Log validity for scaffold decoration
-            if total_generated_count > 0:
-                validity = len(all_generated) / total_generated_count * 100
-                logging.info(f"SAFEGenerator.{task.mode}: validity: {validity:.2f}% ({len(all_generated)} valid SMILES from {total_generated_count} generated)")
+                batch = self.scaffold_decoration(scaffold, batch_size=batch_size, **kwargs)
 
-            return all_generated
+                if not batch:
+                    logging.warning(f"SAFEGenerator.scaffold_decoration returned no SMILES for scaffold {scaffold}.")
+                    continue
+
+                generated_count += len(batch)
+
+                for smi in batch:
+                    if validate_smiles(smi):
+                        valid_smiles.append(smi)
+                        if len(valid_smiles) >= n_samples:
+                            break
 
         elif task.mode == 'linker_generation':
             if not task.fragments or len(task.fragments) < 2:
                 raise ValueError("A list of at least two 'fragments' must be provided for this task.")
             
-            n_samples = config.get('n_samples', 1000)
-            batch_size = config.get('batch_size', 100)
-            sanitize = config.get('sanitize', True)
-            processing_mode = config.get('processing_mode', 'iterate') # iterate or sample
-            # Extract other kwargs for the underlying model
-            kwargs = {k: v for k, v in config.items() if k not in ['n_samples', 'batch_size', 'sanitize', 'processing_mode']}
+            processing_mode = config.get('processing_mode', 'iterate')
 
-            all_generated = []
-            total_generated_count = 0
-
-            if processing_mode == 'iterate':
-                # Generate from each possible pair of fragments
-                fragment_pairs = []
+            fragment_pairs = []
+            if len(task.fragments) >= 2:
                 for i, frag1 in enumerate(task.fragments):
                     for j, frag2 in enumerate(task.fragments[i+1:], i+1):
                         fragment_pairs.append([frag1, frag2])
-                
-                samples_per_pair = n_samples // len(fragment_pairs) if fragment_pairs else n_samples
-                
-                for i, (frag1, frag2) in enumerate(fragment_pairs):
-                    logging.info(f"Generating linker for fragments {i+1}/{len(fragment_pairs)}: {frag1} and {frag2} with {samples_per_pair} samples")
-                    result, generated_count = self.linker_generation(frag1, frag2, n_samples=samples_per_pair, batch_size=batch_size, sanitize=sanitize, **kwargs)
-                    all_generated.extend(result)
-                    total_generated_count += generated_count
-                    
-            elif processing_mode == 'sample':
-                # Randomly sample fragment pairs for each generation
-                for _ in range(n_samples):
-                    selected_fragments = random.sample(task.fragments, 2)
-                    logging.info(f"Generating linker for randomly sampled fragments: {selected_fragments[0]} and {selected_fragments[1]} with 1 sample")
-                    result, generated_count = self.linker_generation(selected_fragments[0], selected_fragments[1], n_samples=1, batch_size=batch_size, sanitize=sanitize, **kwargs)
-                    all_generated.extend(result)
-                    total_generated_count += generated_count
-            else:
-                raise ValueError(f"Unknown processing_mode: {processing_mode}. Must be 'iterate' or 'sample'")
 
-            # Log validity for linker generation
-            if total_generated_count > 0:
-                validity = len(all_generated) / total_generated_count * 100
-                logging.info(f"SAFEGenerator.{task.mode}: validity: {validity:.2f}% ({len(all_generated)} valid SMILES from {total_generated_count} generated)")
-            
-            return all_generated
+            if not fragment_pairs:
+                raise ValueError("Could not form any fragment pairs from the provided fragments.")
+
+            pair_idx = 0
+
+            while len(valid_smiles) < n_samples:
+                if processing_mode == 'iterate':
+                    frag1, frag2 = fragment_pairs[pair_idx % len(fragment_pairs)]
+                    pair_idx += 1
+                elif processing_mode == 'sample':
+                    frag1, frag2 = random.choice(fragment_pairs)
+
+                batch = self.linker_generation(frag1, frag2, batch_size=batch_size, **kwargs)
+
+                if not batch:
+                    logging.warning(f"SAFEGenerator.linker_generation returned no SMILES for fragments {frag1}, {frag2}.")
+                    continue
+
+                generated_count += len(batch)
+                
+                for smi in batch:
+                    if validate_smiles(smi):
+                        valid_smiles.append(smi)
+                        if len(valid_smiles) >= n_samples:
+                            break
         else:
             raise NotImplementedError(f"SAFE-GPT does not support the '{task.mode}' generation mode.")
 
-    def scaffold_decoration(self, scaffold: str, n_samples: int = 1000, batch_size: int = 100, sanitize: bool = True, **kwargs) -> tuple[List[str], int]:
-        valid_smiles = []
-        generated_count = 0
-        
-        while len(valid_smiles) < n_samples:
-            current_batch_size = min(batch_size, n_samples - len(valid_smiles))
-            batch = self.designer.scaffold_decoration(scaffold=scaffold, n_samples_per_trial=current_batch_size, n_trials=1, **kwargs)
-            
-            if not batch:
-                logging.warning("SAFEGenerator.scaffold_decoration returned no SMILES. Stopping generation.")
-                break
-            generated_count += len(batch)
-            
-            # Filter valid SMILES
-            for smi in batch:
-                if validate_smiles(smi):
-                    valid_smiles.append(smi)
-                    if len(valid_smiles) >= n_samples:
-                        break
-        
-        return valid_smiles[:n_samples], generated_count
+        if generated_count > 0:
+            validity = len(valid_smiles) / generated_count * 100
+            logging.info(f"SAFEGenerator.{task.mode}: validity: {validity:.2f}% ({len(valid_smiles)} valid SMILES from {generated_count} generated)")
 
-    def linker_generation(self, fragment1: str, fragment2: str, n_samples: int = 1000, batch_size: int = 100, sanitize: bool = True, **kwargs) -> tuple[List[str], int]:
-        valid_smiles = []
-        generated_count = 0
-        
-        while len(valid_smiles) < n_samples:
-            current_batch_size = min(batch_size, n_samples - len(valid_smiles))
-            batch = self.designer.linker_generation(fragment1, fragment2, n_samples_per_trial=current_batch_size, n_trials=1, **kwargs)
-            
-            if not batch:
-                logging.warning("SAFEGenerator.linker_generation returned no SMILES. Stopping generation.")
-                break
-            generated_count += len(batch)
-            
-            # Filter valid SMILES
-            for smi in batch:
-                if validate_smiles(smi):
-                    valid_smiles.append(smi)
-                    if len(valid_smiles) >= n_samples:
-                        break
-        
-        return valid_smiles[:n_samples], generated_count
-
-    def generate(self, task: GenerationTask) -> List[str]:
-        config = task.config or {}
-        if task.mode == 'de_novo':
-            n_samples = config.get('n_samples', 1000)
-            batch_size = config.get('batch_size', 100)
-            sanitize = config.get('sanitize', True)
-            # Extract other kwargs for the underlying model
-            kwargs = {k: v for k, v in config.items() if k not in ['n_samples', 'batch_size', 'sanitize']}
-            return self.de_novo(n_samples=n_samples, batch_size=batch_size, sanitize=sanitize, **kwargs)
-        elif task.mode == 'scaffold_decoration':
-            if not task.scaffold:
-                raise ValueError("A 'scaffold' must be provided for this task.")
-
-            scaffolds = [task.scaffold] if isinstance(task.scaffold, str) else task.scaffold
-            processing_mode = config.get('processing_mode', 'iterate') # iterate or sample
-            n_samples = config.get('n_samples', 1000)
-            samples_per_scaffold = n_samples // len(scaffolds)
-            batch_size = config.get('batch_size', 100)
-            sanitize = config.get('sanitize', True)
-            # Extract other kwargs for the underlying model
-            kwargs = {k: v for k, v in config.items() if k not in ['n_samples', 'batch_size', 'sanitize', 'processing_mode']}
-
-            all_generated = []
-
-            if processing_mode == 'iterate':
-                for scaffold in scaffolds:
-                    logging.info(f"Decorating scaffold: {scaffold} with {samples_per_scaffold} samples")
-                    all_generated.extend(self.scaffold_decoration(scaffold, n_samples=samples_per_scaffold, batch_size=batch_size, sanitize=sanitize, **kwargs))
-            elif processing_mode == 'sample':
-                import random
-                for _ in range(n_samples):
-                    scaffold = random.choice(scaffolds)
-                    logging.info(f"Decorating scaffold: {scaffold} with 1 sample")
-                    all_generated.extend(self.scaffold_decoration(scaffold, n_samples=1, batch_size=batch_size, sanitize=sanitize, **kwargs))
-
-            return all_generated
-
-        elif task.mode == 'linker_generation':
-            if not task.fragments or len(task.fragments) < 2:
-                raise ValueError("A list of at least two 'fragments' must be provided for this task.")
-            
-            n_samples = config.get('n_samples', 1000)
-            batch_size = config.get('batch_size', 100)
-            sanitize = config.get('sanitize', True)
-            processing_mode = config.get('processing_mode', 'iterate') # iterate or sample
-            # Extract other kwargs for the underlying model
-            kwargs = {k: v for k, v in config.items() if k not in ['n_samples', 'batch_size', 'sanitize', 'processing_mode']}
-
-            all_generated = []
-            total_generated_count = 0
-
-            if processing_mode == 'iterate':
-                # Generate from each possible pair of fragments
-                fragment_pairs = []
-                for i, frag1 in enumerate(task.fragments):
-                    for j, frag2 in enumerate(task.fragments[i+1:], i+1):
-                        fragment_pairs.append([frag1, frag2])
-                
-                samples_per_pair = n_samples // len(fragment_pairs) if fragment_pairs else n_samples
-                
-                for i, (frag1, frag2) in enumerate(fragment_pairs):
-                    result, generated_count = self.linker_generation(frag1, frag2, n_samples=samples_per_pair, batch_size=batch_size, sanitize=sanitize, **kwargs)
-                    all_generated.extend(result)
-                    total_generated_count += generated_count
-                    
-            elif processing_mode == 'sample':
-                # Randomly sample fragment pairs for each generation
-                for _ in range(n_samples):
-                    selected_fragments = random.sample(task.fragments, 2)
-                    result, generated_count = self.linker_generation(selected_fragments[0], selected_fragments[1], n_samples=1, batch_size=batch_size, sanitize=sanitize, **kwargs)
-                    all_generated.extend(result)
-                    total_generated_count += generated_count
-            else:
-                raise ValueError(f"Unknown processing_mode: {processing_mode}. Must be 'iterate' or 'sample'")
-
-            # Log validity for linker generation
-            if total_generated_count > 0:
-                validity = len(all_generated) / total_generated_count * 100
-                logging.info(f"SAFEGenerator.{task.mode}: validity: {validity:.2f}% ({len(all_generated)} valid SMILES from {total_generated_count} generated)")
-            
-            return all_generated
-        else:
-            raise NotImplementedError(f"SAFE-GPT does not support the '{task.mode}' generation mode.")
+        return valid_smiles[:n_samples]
 
 class MolMIMClient(BaseGenerator):
     """
@@ -551,17 +363,16 @@ class MolMIMClient(BaseGenerator):
         if not task.seed_smiles:
             raise ValueError("A 'seed_smiles' string or list must be provided for MolMiM.")
 
-        # Parse configuration
         config = task.config or {}
         n_samples = config.get('n_samples', 10)
         batch_size = config.get('batch_size', 10)
         processing_mode = config.get('processing_mode', 'iterate')
         objective = task.objective or 'QED'
 
-        # Normalize seed_smiles to list
         seed_smiles_list = [task.seed_smiles] if isinstance(task.seed_smiles, str) else task.seed_smiles
+        if not seed_smiles_list:
+            raise ValueError("'seed_smiles' list cannot be empty.")
 
-        # Determine generation algorithm based on task mode
         if task.mode == 'property_optimization':
             algorithm = 'CMA-ES'
         elif task.mode == 'biased_generation':
@@ -569,7 +380,6 @@ class MolMIMClient(BaseGenerator):
         else:
             raise NotImplementedError(f"MolMiM does not support the '{task.mode}' generation mode.")
 
-        # Build optimization parameters
         optimize_params = {
             "iterations": config.get('iterations', 10),
             "min_similarity": config.get('min_similarity', 0.7),
@@ -579,101 +389,45 @@ class MolMIMClient(BaseGenerator):
             "scaled_radius": config.get('scaled_radius', 1.0)
         }
 
-        # Process seeds according to processing mode
-        all_generated = []
-        
-        if processing_mode == 'iterate':
-            # Generate from each seed sequentially
-            samples_per_seed = n_samples // len(seed_smiles_list)
-            for seed in seed_smiles_list:
-                logging.info(f"Generating from seed: {seed} with {samples_per_seed} samples")
-                
-                # Generate molecules from this seed
-                valid_smiles = []
-                generated_count = 0
-                
-                while len(valid_smiles) < samples_per_seed:
-                    try:
-                        # Call MolMiM API
-                        smiles_batch = self.optimize(
-                            seed_smiles=seed,
-                            algorithm=algorithm,
-                            n_samples=batch_size,
-                            **optimize_params
-                        )
-                        
-                        if not smiles_batch:
-                            logging.warning(f"MolMiM returned no SMILES for seed: {seed}")
-                            break
-                        
-                        generated_count += len(smiles_batch)
-                        
-                        # Filter valid SMILES
-                        for smi in smiles_batch:
-                            if validate_smiles(smi):
-                                valid_smiles.append(smi)
-                                if len(valid_smiles) >= samples_per_seed:
-                                    break
-                                    
-                    except requests.exceptions.RequestException as e:
-                        logging.error(f"MolMiM API call failed for seed {seed}: {e}")
-                        break
-
-                # Log validity statistics for this seed
-                if generated_count > 0:
-                    validity = len(valid_smiles) / generated_count * 100
-                    logging.info(f"MolMIMClient.{task.mode}: validity: {validity:.2f}% ({len(valid_smiles)} valid SMILES from {generated_count} generated)")
-                
-                all_generated.extend(valid_smiles[:samples_per_seed])
-
-        elif processing_mode == 'sample':
-            # Randomly sample seeds for each generation
-            for _ in range(n_samples):
+        valid_smiles = []
+        generated_count = 0
+        seed_idx = 0
+        while len(valid_smiles) < n_samples:
+            if processing_mode == 'iterate':
+                seed = seed_smiles_list[seed_idx % len(seed_smiles_list)]
+                seed_idx += 1
+            elif processing_mode == 'sample':
                 seed = random.choice(seed_smiles_list)
-                logging.info(f"Generating from seed: {seed} with 1 sample")
+
+            try:
+                smiles_batch = self.optimize(
+                    seed_smiles=seed,
+                    algorithm=algorithm,
+                    n_samples=batch_size,
+                    **optimize_params
+                )
                 
-                # Generate molecules from this seed
-                valid_smiles = []
-                generated_count = 0
+                if not smiles_batch:
+                    logging.warning(f"MolMiM returned no SMILES for seed: {seed}")
+                    continue
                 
-                while len(valid_smiles) < 1:
-                    try:
-                        # Call MolMiM API
-                        smiles_batch = self.optimize(
-                            seed_smiles=seed,
-                            algorithm=algorithm,
-                            n_samples=batch_size,
-                            **optimize_params
-                        )
-                        
-                        if not smiles_batch:
-                            logging.warning(f"MolMiM returned no SMILES for seed: {seed}")
+                generated_count += len(smiles_batch)
+                
+                for smi in smiles_batch:
+                    if validate_smiles(smi):
+                        valid_smiles.append(smi)
+                        if len(valid_smiles) >= n_samples:
                             break
-                        
-                        generated_count += len(smiles_batch)
-                        
-                        # Filter valid SMILES
-                        for smi in smiles_batch:
-                            if validate_smiles(smi):
-                                valid_smiles.append(smi)
-                                if len(valid_smiles) >= 1:
-                                    break
-                                    
-                    except requests.exceptions.RequestException as e:
-                        logging.error(f"MolMiM API call failed for seed {seed}: {e}")
-                        break
 
-                # Log validity statistics for this seed
-                if generated_count > 0:
-                    validity = len(valid_smiles) / generated_count * 100
-                    logging.info(f"MolMIMClient.{task.mode}: validity: {validity:.2f}% ({len(valid_smiles)} valid SMILES from {generated_count} generated)")
-                
-                all_generated.extend(valid_smiles[:1])
+            except requests.exceptions.RequestException as e:
+                logging.error(f"MolMiM API call failed for seed {seed}: {e}")
+                continue
 
-        else:
-            raise ValueError(f"Unknown processing_mode: {processing_mode}. Must be 'iterate' or 'sample'")
+        if generated_count > 0:
+            validity = len(valid_smiles) / generated_count * 100
+            logging.info(f"MolMIMClient.{task.mode}: validity: {validity:.2f}% ({len(valid_smiles)} valid SMILES from {generated_count} generated)")
 
-        return all_generated
+        return valid_smiles[:n_samples]
 
 class GEMGenerator(BaseGenerator):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ mpmath==1.3.0
 multidict==6.5.0
 multiprocess==0.70.16
 networkx==3.4.2
-numpy==1.25.0
+numpy
 nvidia-cublas-cu12==12.6.4.1
 nvidia-cuda-cupti-cu12==12.6.80
 nvidia-cuda-nvrtc-cu12==12.6.77


### PR DESCRIPTION
This commit refactors the generation models in `argo/gen_models/__init__.py`.

- Removes the `labels` attribute from the `GenerationTask` dataclass.
- Refactors `SAFEGenerator` to move SMILES validation and batch generation logic into the `generate` method. The `de_novo`, `scaffold_decoration`, and `linker_generation` methods now only generate a single batch.
- Simplifies the `iterate` and `sample` logic in `SAFEGenerator` to be batch-based.
- Applies a similar batch-based `iterate` and `sample` logic to `MolMIMClient` for `seed_smiles`.